### PR TITLE
Module objects are usually not callable.

### DIFF
--- a/ffn_bot/reddit_bot.py
+++ b/ffn_bot/reddit_bot.py
@@ -175,7 +175,7 @@ if platform.system() == "Windows":
 else:
     def wait(timeout=1):
         import sys, select
-        rlist, wlist, xlist = select([sys.stdin], [], [], timeout)
+        rlist, wlist, xlist = select.select([sys.stdin], [], [], timeout)
         return bool(rlist)
 
 def pause(minutes, seconds):


### PR DESCRIPTION
Of course I wanted to call the function select in the select module.
Fixes #12
Adding to #9 