### PR TITLE
Added support for fictionpress.com

### DIFF
--- a/ffn_bot/reddit_bot.py
+++ b/ffn_bot/reddit_bot.py
@@ -23,6 +23,7 @@ CHECKED_COMMENTS = set()
 # REGEXPS = {'[Ll][iI][nN][kK][fF]{2}[nN]\((.*?)\)': 'ffn'}
 SITES = [
     fanfiction_parser.FanfictionNetSite(),
+    fanfiction_parser.FictionPressSite(),
     ao3.ArchiveOfOurOwn()
 ]
 


### PR DESCRIPTION
FFN and FictionPress are hosted by the same people. It even looks the same (except for the color), so what exactly stops us from adding it as a feature.

Usage: Like Fanfiction.Net only with `linkfp(Black Heaven)` instead of linkffn.