### PR TITLE
Fixed non matching ao3 url on parsing

### DIFF
--- a/ffn_bot/ao3.py
+++ b/ffn_bot/ao3.py
@@ -10,7 +10,7 @@ from ffn_bot import site
 
 __all__ = ["ArchiveOfOurOwn"]
 
-AO3_LINK_REGEX = re.compile(r"http(s)?://([^.]\.)?archiveofourown.org/works/(?P<sid>\d+).*", re.IGNORECASE)
+AO3_LINK_REGEX = re.compile(r"http(s)?://([^.]+\.)?archiveofourown.org/works/(?P<sid>\d+).*", re.IGNORECASE)
 AO3_FUNCTION = "linkao3"
 AO3_SEARCH_QUERY = "site:archiveofourown.org/works/ %s"
 
@@ -67,7 +67,7 @@ class ArchiveOfOurOwn(Site):
         # Filter out direct links.
         match = AO3_LINK_REGEX.match(request)
         if match is not None:
-            return match
+            return request
 
         search_request = search(AO3_SEARCH_QUERY % request, num=1, stop=1)
         try:


### PR DESCRIPTION
Found a bug in the ao3-regex that causes the link_finder function to fail on returning the link when we pass the direct link: `linkao3(http://archiveofourown.org/works/123456/)`
