### PR TITLE
Fix incorrect page link on ao3.

### DIFF
--- a/ffn_bot/ao3.py
+++ b/ffn_bot/ao3.py
@@ -91,6 +91,7 @@ class Story(site.Story):
 
     def get_real_url(self):
         return "http://archiveofourown.org/works/%s" % AO3_LINK_REGEX.match(self.url).groupdict()["sid"]
+    get_url = get_real_url
 
     def get_value_from_tree(self, xpath, sep=""):
         return sep.join(self.tree.xpath(xpath)).strip()


### PR DESCRIPTION
Noticed that google does not always spit the correct URL out, so we will use the automatically generated url instead of the search result url.