### PR TITLE
Added support to modify bot behaviour

### DIFF
--- a/ffn_bot/fanfiction_parser.py
+++ b/ffn_bot/fanfiction_parser.py
@@ -29,14 +29,14 @@ class FanfictionBaseSite(site.Site):
             LINK_REGEX % self.site.replace(".", "\\."), re.IGNORECASE)
         self.id_link = ID_LINK.format(self.site)
 
-    def from_requests(self, requests):
+    def from_requests(self, requests, context):
         # I'd love to use 'yield from'
         for request in requests:
-            yield self.process(request)
+            yield self.process(request, context)
 
-    def process(self, request):
+    def process(self, request, context):
         try:
-            link = self.find_link(request)
+            link = self.find_link(request, context)
         except (StopIteration, Exception) as e:
             bot_tools.print_exception()
             return None
@@ -45,12 +45,12 @@ class FanfictionBaseSite(site.Site):
             return None
 
         try:
-            return Story(link, self.site)
+            return Story(link, self.site, context)
         except Exception as e:
             bot_tools.print_exception()
             return None
 
-    def find_link(self, fic_name):
+    def find_link(self, fic_name, context):
         # Prevent users from crashing program with bad link names.
         fic_name = fic_name.encode('ascii', errors='replace')
         fic_name = fic_name.decode('ascii', errors='replace')
@@ -74,9 +74,10 @@ class FanfictionBaseSite(site.Site):
         return default_cache.search(search_request)
 
 
-class _Story(site.Story):
+class Story(site.Story):
 
-    def __init__(self, url, site):
+    def __init__(self, url, site, context):
+        super(Story, self).__init__(context)
         self.url = url
         self.site = site
         self.raw_stats = []
@@ -139,23 +140,5 @@ class FictionPressSite(FanfictionBaseSite):
     def __init__(self, command="linkfp", name=None):
         super(FictionPressSite, self).__init__("fictionpress.com", "linkfp", name)
 
+# We don't need to cache the story objects anymore.
 
-try:
-    from functools import lru_cache
-except ImportError:
-    print("Python version too old for caching.")
-    Story = _Story
-else:
-    # We will use a simple lru_cache for now.
-    @lru_cache(maxsize=10000)
-    def Story(url, site):
-        return _Story(url, site)
-
-# # DEBUG
-# x = Story('https://www.fanfiction.net/s/11096853/1/She-Chose-Me')  # No self.image
-# print(str(x))
-# print(x.authorlink)
-# print(x.title)
-# print(x.author)
-# print(x.summary)
-# print(x.stats)

--- a/ffn_bot/ffa.py
+++ b/ffn_bot/ffa.py
@@ -32,12 +32,12 @@ class HPFanfictionArchive(Site):
     def __init__(self, regex=FFA_FUNCTION + r"\((.*?)\)", name=None):
         super(HPFanfictionArchive, self).__init__(regex, name)
 
-    def from_requests(self, requests):
+    def from_requests(self, requests, context):
         _pitem = []
         item = _pitem
         for request in requests:
             try:
-                item = self.process(request)
+                item = self.process(request, context)
             except Exception as e:
                 continue
 
@@ -46,9 +46,9 @@ class HPFanfictionArchive(Site):
         # Make sure we yield something.
         yield ""
 
-    def process(self, request):
+    def process(self, request, context):
         try:
-            link = self.find_link(request)
+            link = self.find_link(request, context)
         except IOError as e:
             logging.error("FF not found: %s" % request)
             return
@@ -56,9 +56,9 @@ class HPFanfictionArchive(Site):
         if link is None:
             return
 
-        return self.generate_response(link)
+        return self.generate_response(link, context)
 
-    def find_link(self, request):
+    def find_link(self, request, context):
         # Find link by ID.
         id = safe_int(request)
         if id is not None:
@@ -71,17 +71,18 @@ class HPFanfictionArchive(Site):
 
         return default_cache.search(FFA_SEARCH_QUERY % request)
 
-    def generate_response(self, link):
+    def generate_response(self, link, context):
         assert link is not None
-        return Story(link)
+        return Story(link, context)
 
     def get_story(self, query):
-        return Story(self.find_link(query))
+        return Story(self.find_link(query, set()))
 
 
 class Story(site.Story):
 
-    def __init__(self, url):
+    def __init__(self, url, context=None):
+        super(Story, self).__init__(context)
         self.url = url
         self.raw_stats = []
 

--- a/ffn_bot/site.py
+++ b/ffn_bot/site.py
@@ -25,7 +25,7 @@ class Site(object):
         self.regex = regex
         self.name = name
 
-    def from_requests(self, requests):
+    def from_requests(self, requests, context):
         """
         Returns an iterable of story objects that are assiciated with this request.
         :param request:  The list of request that have been sent.
@@ -40,8 +40,8 @@ class Story(object):
     Represents a single story.
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, context=None):
+        self.context = set() if context is None else context
 
     def get_title(self):
         """Returns the title of the story"""
@@ -87,6 +87,10 @@ class Story(object):
         return "\n".join(result)
 
     def format_stats(self):
+        # Allow the user to opt out of the reformatting
+        if "noreformat" in self.context:
+            return
+
         self.stats = re.sub('(\w+:)', '\n\n*' + r"\1" + '*', self.stats)
         self.stats = re.sub('((\w|[/,\.\-\(])+)', '' + r'\1', self.stats)
         self.stats = re.sub('([\n]+)', '\n', self.stats)


### PR DESCRIPTION
In preparation to support automatic fetching of links I thought we could add a marker
that prevents the bot to parse the message.

This marker is automatically added to the reply so that the reply may not be parsed in any
way.

In addition it can be used to activate/deactivate experimental features of the bot.

Add ffnbot!ignore to ignore the comment entirely
Add ffnbot!noreformat to suppress automatic reformatting (that routinely fails).

Side Note: FFN-Story instances are not cached anymore.