### PR TITLE
Make stories distinct

### DIFF
--- a/ffn_bot/fanfiction_parser.py
+++ b/ffn_bot/fanfiction_parser.py
@@ -15,7 +15,7 @@ from lxml import html
 
 __all__ = ["FanfictionNetSite", "FictionPressSite"]
 
-LINK_REGEX = "http(s?)://((www|m)\\.)?%s/s/(\\d+)/.*"
+LINK_REGEX = "http(s?)://((www|m)\\.)?%s/s/(?P<sid>\\d+).*"
 ID_LINK = "https://www.{0}/s/%s"
 
 
@@ -87,8 +87,14 @@ class Story(site.Story):
         self.encode()
         self.decode()
 
+    def get_url(self):
+        return "http://www.%s/s/%s/1/" % (
+            self.site,
+            re.match(LINK_REGEX%self.site, self.url).groupdict()["sid"]
+        )
+
     def parse_html(self):
-        page = default_cache.get_page(self.url, throttle=randint(1000,4000)/1000)
+        page = default_cache.get_page(self.get_url(), throttle=randint(1000,4000)/1000)
         tree = html.fromstring(page)
 
         self.title = (tree.xpath('//*[@id="profile_top"]/b/text()'))[0]

--- a/ffn_bot/reddit_bot.py
+++ b/ffn_bot/reddit_bot.py
@@ -34,6 +34,7 @@ SITES = [
 # Currently only two marker is supported:
 # ffnbot!ignore              Ignore the comment entirely
 # ffnbot!noreformat          Fix FFN formatting by not reformatting.
+# ffnbot!nodistinct          Don't make sure that we get distinct requests
 #
 # However more could be implemented like
 # ffnbot!ignorecache,nothrottle               # Not Implemented
@@ -231,6 +232,7 @@ def parse_context_markers(comment_body):
         )
     )
 
+
 def formulate_reply(comment_body):
     """Creates the reply for the given comment."""
 
@@ -255,7 +257,10 @@ def parse_comment_requests(requests, context):
     Executes the queries and return the
     generated story strings as a single string
     """
-    return "".join(_parse_comment_requests(requests, context))
+    results = _parse_comment_requests(requests, context)
+    if "nodistinct" not in context:
+        results = set(results)
+    return "".join(results)
 
 
 def _parse_comment_requests(requests, context):

--- a/ffn_bot/reddit_bot.py
+++ b/ffn_bot/reddit_bot.py
@@ -276,7 +276,6 @@ def parse_comment_requests(requests, context, additions):
 
     if "nodistinct" not in context:
         results = set(results)
-
     return "".join(str(result) for result in results if result)
 
 

--- a/ffn_bot/site.py
+++ b/ffn_bot/site.py
@@ -124,3 +124,7 @@ class Story(object):
     def __hash__(self):
         # We will use the URL for a hash.
         return hash(self.get_url())
+    def __eq__(self, other):
+        if not isinstance(other, Story):
+            return False
+        return other.get_url() == self.get_url()

--- a/ffn_bot/site.py
+++ b/ffn_bot/site.py
@@ -107,3 +107,7 @@ class Story(object):
         self.stats = self.stats.replace("^(> ^(", "^(")
         self.stats = self.stats.replace("> ^(> ^(", "> ^(")
         self.stats = re.sub('([\)]+)', ')', self.stats)
+
+    def __hash__(self):
+        # We will use the URL for a hash.
+        return hash(self.get_url())


### PR DESCRIPTION
Ensure we have a distinct list of stories before we attempt to use link-only parsing to support cases
like "linkffn(<Link here>)"