### PR TITLE
Adding r/harrypotter to the list of subreddits bot

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -12,7 +12,7 @@ username: [REDACTED]
 password: [REDACTED]
 
 [Reddit]
-subreddits: HPFanfiction,WormFanfic,NarutoFanfiction,Fanfiction,fandomnatural,marvelfans,HPSlashFic,thecitadel,HPHarmony,MiraculousFanfiction
+subreddits: harrypotter,HPFanfiction,WormFanfic,NarutoFanfiction,Fanfiction,fandomnatural,marvelfans,HPSlashFic,thecitadel,HPHarmony,MiraculousFanfiction
 footer: **FanfictionBot**^(2.0.0-beta) | [Usage](https://github.com/tusing/reddit-ffn-bot/wiki/Usage) | [Contact](https://www.reddit.com/message/compose?to=tusing)
     ^^^^^^^^^^^^^^^^^ffnbot!ignore
 ; The maximum number of replies a user can make


### PR DESCRIPTION
Adds r/harrypotter to the list of subreddits to which the bot responds. I mean, there are a suprising number of fanfiction threads in the threads.